### PR TITLE
Switching to distroless Java 17 to run the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mvn clean package -DskipTests -ntp && \
   mv /app/target/*.jar /app/build/
 
 # Stage 2: Run the application
-FROM amazoncorretto:17-alpine-jdk
+FROM gcr.io/distroless/java17-debian12
 WORKDIR /app
 COPY --from=build /app/build/*.jar app.jar
 EXPOSE 8080


### PR DESCRIPTION
This is an attempt to fix https://github.com/UnitVectorY-Labs/firepubauditsource/pull/1

The problem here looks to be related to https://github.com/grpc/grpc-java/issues/10096#issuecomment-1521958350

Specifically these newer versions don't look to be compatible with Alpine so the change here is to move to distroless.